### PR TITLE
fix/update Me3.getAuthToken() to return tokens

### DIFF
--- a/packages/keysmith/src/types.ts
+++ b/packages/keysmith/src/types.ts
@@ -17,13 +17,10 @@ interface RsaKey {
 interface Tokens {
   kc_access: string;
   kc_refresh: string;
-
   // Google access token
   google_access: string;
-
   // Server side rsa pub key
   rsaPubKey: string;
-
   // Will be not null only for new users
   uid?: string;
   password?: string;


### PR DESCRIPTION
Changes:
- Me3.getAuthToken() now returns all Keycloak-managed tokens (kc_access, kc_refresh and google_access)